### PR TITLE
Add Cyber Security Training view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,8 +7,8 @@ import toolbar from '/src/components/main-toolbar.vue'
   <header>
     <img alt="Leguan Academy logo" src="@/assets/logo2.png" width="125" height="125" />
     <p>Hi my name is Iggy, Iggy the Iguana</p>
-    <div><h1> Leguan Academy</h1></div>
-    <div><h2> Digital Education for Children</h2></div>
+    <div><h1>Leguan Academy</h1></div>
+    <div><h2>Digital Education for Children</h2></div>
     <div>
       <nav>
         <RouterLink to="/">Home</RouterLink>
@@ -16,6 +16,7 @@ import toolbar from '/src/components/main-toolbar.vue'
         <RouterLink to="/Keyboard">Keyboard</RouterLink>
         <RouterLink to="/treasurehunt">Treasure Hunt</RouterLink>
         <RouterLink to="/crocoslunch">Crocos Lunch</RouterLink>
+        <RouterLink to="/cybersec">Cyber Security Training</RouterLink>
         <RouterLink to="/opensource">Open Source Contribution</RouterLink>
         <RouterLink to="/privacy">Privacy</RouterLink>
       </nav>
@@ -23,24 +24,33 @@ import toolbar from '/src/components/main-toolbar.vue'
     </div>
     <footer>
       <form action="https://www.paypal.com/donate" method="post" target="_top">
-<input type="hidden" name="hosted_button_id" value="HEJDHAV6GQ8QL" />
-<input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Donate with PayPal button" />
-<img alt="" border="0" src="https://www.paypal.com/en_DE/i/scr/pixel.gif" width="1" height="1" />
-</form>
+        <input type="hidden" name="hosted_button_id" value="HEJDHAV6GQ8QL" />
+        <input
+          type="image"
+          src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif"
+          border="0"
+          name="submit"
+          title="PayPal - The safer, easier way to pay online!"
+          alt="Donate with PayPal button"
+        />
+        <img
+          alt=""
+          border="0"
+          src="https://www.paypal.com/en_DE/i/scr/pixel.gif"
+          width="1"
+          height="1"
+        />
+      </form>
 
-<a href="#">Impressum</a>
-<router-link to="/privacy">Privacy</router-link>
-
-  </footer>
+      <a href="#">Impressum</a>
+      <router-link to="/privacy">Privacy</router-link>
+    </footer>
   </header>
-
-  
-
 </template>
 
 <style scoped>
 .fund-me-button {
-  background-color: #4CAF50; /* Green */
+  background-color: #4caf50; /* Green */
   border: none;
   color: white;
   padding: 15px 32px;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,7 +4,7 @@ import PrivacyPolicyViewVue from '@/views/PrivacyPolicyView.vue'
 import KeyboardViewVue from '@/views/KeyboardView.vue'
 import TreasureHuntViewVue from '@/views/TreasureHuntView.vue'
 import CrocsLunchViewVue from '@/views/CrocsLunchView.vue'
-
+import CyberSecViewVue from '@/views/CyberSecView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -22,33 +22,38 @@ const router = createRouter({
       // which is lazy-loaded when the route is visited.
       component: () => import('../views/AboutView.vue')
     },
-  {
-    path: '/keyboard',
-    name: 'keyboard',
-    component: KeyboardViewVue
-  },
-  {
-    path: '/treasurehunt',
-    name: 'treasurehunt',
-    component: TreasureHuntViewVue
-  },
-  {
-    path: '/crocoslunch',
-    name: 'crocoslunch',
-    component: CrocsLunchViewVue
-  },
-  {
-    path: '/privacy',
-    name:'privacy',
-    component: PrivacyPolicyViewVue
-  },
-  {
-    path: '/opensource',
-    name: 'OpenSource',
-    beforeEnter: (to, from, next) => {
-      window.location.href = 'https://github.com/sabinahschmitz/Leguan-academy/';
+    {
+      path: '/keyboard',
+      name: 'keyboard',
+      component: KeyboardViewVue
+    },
+    {
+      path: '/treasurehunt',
+      name: 'treasurehunt',
+      component: TreasureHuntViewVue
+    },
+    {
+      path: '/crocoslunch',
+      name: 'crocoslunch',
+      component: CrocsLunchViewVue
+    },
+    {
+      path: '/cybersec',
+      name: 'cybersec',
+      component: CyberSecViewVue
+    },
+    {
+      path: '/privacy',
+      name: 'privacy',
+      component: PrivacyPolicyViewVue
+    },
+    {
+      path: '/opensource',
+      name: 'OpenSource',
+      beforeEnter: (to, from, next) => {
+        window.location.href = 'https://github.com/sabinahschmitz/Leguan-academy/'
+      }
     }
-  },
   ]
 })
 

--- a/src/views/CyberSecView.vue
+++ b/src/views/CyberSecView.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="cybersec-view">
+    <h1>Cyber Security Training</h1>
+    <div class="game-area">
+      <div class="game-frame">
+        <p class="placeholder">Game frame</p>
+      </div>
+      <div class="sidebar">
+        <button class="play-button" @click="playGame">Play</button>
+        <div class="level-selector">
+          <label for="level">Level:</label>
+          <select id="level" v-model="selectedLevel">
+            <option v-for="level in levels" :key="level" :value="level">Level {{ level }}</option>
+          </select>
+        </div>
+        <div class="options">
+          <h2>Settings</h2>
+          <label><input type="checkbox" v-model="motions" /> Motions</label>
+          <label><input type="checkbox" v-model="feedback" /> Feedback</label>
+          <label><input type="checkbox" v-model="bugs" /> Bugs</label>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const levels = [1, 2, 3]
+const selectedLevel = ref(1)
+const motions = ref(true)
+const feedback = ref(true)
+const bugs = ref(false)
+
+function playGame() {
+  console.log(`Play level ${selectedLevel.value}`)
+}
+</script>
+
+<style scoped>
+.cybersec-view {
+  text-align: center;
+}
+
+.game-area {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.game-frame {
+  width: 600px;
+  height: 400px;
+  border: 2px solid #333;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #fff;
+  margin-right: 20px;
+}
+
+.placeholder {
+  color: #888;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.play-button {
+  padding: 10px 20px;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.level-selector,
+.options {
+  text-align: left;
+}
+
+.options label {
+  display: block;
+  margin-bottom: 5px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add Cyber Security Training button to navigation
- create CyberSecView with a placeholder game frame, level selector and options
- register new Cyber Security route

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a2dda3fb88320922fdfc2c34fa674